### PR TITLE
Override datastore entities

### DIFF
--- a/src/routes/authorization.rs
+++ b/src/routes/authorization.rs
@@ -30,11 +30,14 @@ pub async fn is_authorized(
         }
     };
 
-    let (request, entities) = &query.get_request_entities();    
-
     // Temporary solution to override fetching entities from the datastore by directly passing it to the REST body. 
     // Eventually this logic will be replaced in favor of performing live patch updates  
-    let request_entities: cedar_policy::Entities = if *entities == cedar_policy::Entities::empty() { data_store.entities().await } else { entities.clone() };
+    let (request, entities) = &query.get_request_entities();    
+
+    let request_entities = match entities {
+        None => data_store.entities().await,
+        Some(ents) => ents.clone()
+    };    
     
     info!("Querying cedar using {:?}", &request);
     let answer = authorizer.is_authorized(&request, &policies, &request_entities);

--- a/src/routes/authorization.rs
+++ b/src/routes/authorization.rs
@@ -32,7 +32,8 @@ pub async fn is_authorized(
 
     let (request, entities) = &query.get_request_entities();    
 
-    /// temporary solution for now. Eventually this logic will be replaced in favor of performing live patch updates  
+    // Temporary solution to override fetching entities from the datastore by directly passing it to the REST body. 
+    // Eventually this logic will be replaced in favor of performing live patch updates  
     let request_entities: cedar_policy::Entities = if *entities == cedar_policy::Entities::empty() { data_store.entities().await } else { entities.clone() };
     
     info!("Querying cedar using {:?}", &request);

--- a/src/routes/authorization.rs
+++ b/src/routes/authorization.rs
@@ -33,7 +33,7 @@ pub async fn is_authorized(
     let (request, entities) = &query.get_request_entities();    
 
     /// temporary solution for now. Eventually this logic will be replaced in favor of performing live patch updates  
-    let request_entities: cedar_policy::Entities = if *entities == cedar_policy::Entities::empty() { data_store.entities().await } else { entities.clone() };
+    let request_entities: cedar_policy::Entities = if *entities == cedar_policy::Entities::empty() { data_store.entities().await } else { entities };
     
     info!("Querying cedar using {:?}", &request);
     let answer = authorizer.is_authorized(&request, &policies, &request_entities);

--- a/src/routes/authorization.rs
+++ b/src/routes/authorization.rs
@@ -33,7 +33,7 @@ pub async fn is_authorized(
     let (request, entities) = &query.get_request_entities();    
 
     /// temporary solution for now. Eventually this logic will be replaced in favor of performing live patch updates  
-    let request_entities: cedar_policy::Entities = if *entities == cedar_policy::Entities::empty() { data_store.entities().await } else { entities };
+    let request_entities: cedar_policy::Entities = if *entities == cedar_policy::Entities::empty() { data_store.entities().await } else { entities.clone() };
     
     info!("Querying cedar using {:?}", &request);
     let answer = authorizer.is_authorized(&request, &policies, &request_entities);

--- a/src/routes/authorization.rs
+++ b/src/routes/authorization.rs
@@ -8,7 +8,7 @@ use rocket_okapi::openapi;
 
 use crate::authn::ApiKey;
 use crate::errors::response::AgentError;
-use crate::schemas::authorization::{AuthorizationAnswer, AuthorizationCall};
+use crate::schemas::authorization::{AuthorizationAnswer, AuthorizationCall, AuthorizationRequest};
 use crate::{DataStore, PolicyStore};
 
 #[openapi]
@@ -19,10 +19,9 @@ pub async fn is_authorized(
     data_store: &State<Box<dyn DataStore>>,
     authorizer: &State<Authorizer>,
     authorization_call: Json<AuthorizationCall>,
-) -> Result<Json<AuthorizationAnswer>, AgentError> {
-    let entities: cedar_policy::Entities = data_store.entities().await;
+) -> Result<Json<AuthorizationAnswer>, AgentError> {    
     let policies = policy_store.policy_set().await;
-    let query: cedar_policy::Request = match authorization_call.into_inner().try_into() {
+    let query: AuthorizationRequest = match authorization_call.into_inner().try_into() {
         Ok(query) => query,
         Err(err) => {
             return Err(AgentError::BadRequest {
@@ -30,7 +29,13 @@ pub async fn is_authorized(
             })
         }
     };
-    info!("Querying cedar using {}", query);
-    let answer = authorizer.is_authorized(&query, &policies, &entities);
+
+    let (request, entities) = &query.get_request_entities();    
+
+    /// temporary solution for now. Eventually this logic will be replaced in favor of performing live patch updates  
+    let request_entities: cedar_policy::Entities = if *entities == cedar_policy::Entities::empty() { data_store.entities().await } else { entities.clone() };
+    
+    info!("Querying cedar using {:?}", &request);
+    let answer = authorizer.is_authorized(&request, &policies, &request_entities);
     Ok(Json::from(AuthorizationAnswer::from(answer)))
 }

--- a/src/schemas/authorization.rs
+++ b/src/schemas/authorization.rs
@@ -30,16 +30,17 @@ pub struct AuthorizationCall {
 
 pub struct AuthorizationRequest {
     request: Request,
-    entities: Entities
+    entities: Option<Entities>
 }
 
 impl AuthorizationRequest {
 
-    pub fn new(request: Request, entities: Entities) -> AuthorizationRequest {
+    pub fn new(request: Request, entities: Option<Entities>) -> AuthorizationRequest {
         AuthorizationRequest { request, entities }
     }
 
-    pub fn get_request_entities(self) -> (Request, Entities) {
+    pub fn get_request_entities(self) -> (Request, Option<Entities>) {        
+
         (self.request, self.entities)
     }
 }
@@ -73,11 +74,11 @@ impl TryInto<AuthorizationRequest> for AuthorizationCall {
         let entities = match self.entities {            
             Some(et) => match Entities::from_json_value(et, None) {
                 Ok(et) => {
-                    et
+                    Some(et)
                 },
                 Err(e) => return Err(e.into()),
             },
-            None => Entities::empty(),
+            None => None,
         };
         let context = match self.context {
             Some(c) => match Context::from_json_value(c, None) {

--- a/src/schemas/authorization.rs
+++ b/src/schemas/authorization.rs
@@ -2,7 +2,7 @@ use std::collections::HashSet;
 use std::error::Error;
 use std::str::FromStr;
 
-use cedar_policy::{Context, EntityUid, EvaluationError, Request, Response};
+use cedar_policy::{Context, EntityUid, EvaluationError, Request, Response, Entities};
 use cedar_policy_core::authorizer::Decision;
 use cedar_policy_core::parser::err::ParseErrors;
 
@@ -17,18 +17,31 @@ pub struct AuthorizationCall {
     action: Option<String>,
     resource: Option<String>,
     context: Option<serde_json::Value>,
+    entities: Option<serde_json::Value>,
     /// Optional schema in JSON format.
     /// If present, this will inform the parsing: for instance, it will allow
     /// `__entity` and `__extn` escapes to be implicit, and it will error if
     /// attributes have the wrong types (e.g., string instead of integer).
     /// currently unsupported
     #[schemars(skip)]
-    policies: Option<String>,
-    /// JSON object containing the entities data, in "natural JSON" form -- same
-    /// format as expected by EntityJsonParser
-    /// currently unsupported
-    #[schemars(skip)]
-    entities: Option<serde_json::Value>,
+    policies: Option<String>,  
+    
+}
+
+pub struct AuthorizationRequest {
+    request: Request,
+    entities: Entities
+}
+
+impl AuthorizationRequest {
+
+    pub fn new(request: Request, entities: Entities) -> AuthorizationRequest {
+        AuthorizationRequest { request, entities }
+    }
+
+    pub fn get_request_entities(self) -> (Request, Entities) {
+        (self.request, self.entities)
+    }
 }
 
 fn string_to_euid(optional_str: Option<String>) -> Result<Option<EntityUid>, ParseErrors> {
@@ -41,10 +54,10 @@ fn string_to_euid(optional_str: Option<String>) -> Result<Option<EntityUid>, Par
     }
 }
 
-impl TryInto<Request> for AuthorizationCall {
+impl TryInto<AuthorizationRequest> for AuthorizationCall {
     type Error = Box<dyn Error>;
 
-    fn try_into(self) -> Result<Request, Self::Error> {
+    fn try_into(self) -> Result<AuthorizationRequest, Self::Error> {
         let principal = match string_to_euid(self.principal) {
             Ok(p) => p,
             Err(e) => return Err(e.into()),
@@ -57,6 +70,15 @@ impl TryInto<Request> for AuthorizationCall {
             Ok(r) => r,
             Err(e) => return Err(e.into()),
         };
+        let entities = match self.entities {            
+            Some(et) => match Entities::from_json_value(et, None) {
+                Ok(et) => {
+                    et
+                },
+                Err(e) => return Err(e.into()),
+            },
+            None => Entities::empty(),
+        };
         let context = match self.context {
             Some(c) => match Context::from_json_value(c, None) {
                 Ok(c) => c,
@@ -64,7 +86,7 @@ impl TryInto<Request> for AuthorizationCall {
             },
             None => Context::empty(),
         };
-        Ok(Request::new(principal, action, resource, context))
+        Ok(AuthorizationRequest::new(Request::new(principal, action, resource, context), entities))
     }
 }
 

--- a/src/schemas/authorization.rs
+++ b/src/schemas/authorization.rs
@@ -2,6 +2,7 @@ use std::collections::HashSet;
 use std::error::Error;
 use std::str::FromStr;
 
+
 use cedar_policy::{Context, EntityUid, EvaluationError, Request, Response, Entities};
 use cedar_policy_core::authorizer::Decision;
 use cedar_policy_core::parser::err::ParseErrors;
@@ -39,6 +40,10 @@ impl AuthorizationRequest {
         AuthorizationRequest { request, entities }
     }
 
+    pub fn get_entities(self) -> Option<Entities> {
+        self.entities
+    }
+
     pub fn get_request_entities(self) -> (Request, Option<Entities>) {        
 
         (self.request, self.entities)
@@ -53,6 +58,14 @@ fn string_to_euid(optional_str: Option<String>) -> Result<Option<EntityUid>, Par
         },
         None => Ok(None),
     }
+}
+
+impl AuthorizationCall {
+
+    pub fn new(principal: Option<String>, action: Option<String>, resource: Option<String>, context:Option<rocket::serde::json::Value>, entities:Option<rocket::serde::json::Value>, policies: Option<String>) -> AuthorizationCall {
+        AuthorizationCall { principal, action, resource, context, entities, policies }
+    }
+
 }
 
 impl TryInto<AuthorizationRequest> for AuthorizationCall {

--- a/tests/services/data_tests.rs
+++ b/tests/services/data_tests.rs
@@ -1,10 +1,14 @@
 use std::path::PathBuf;
 
 use crate::services::utils;
+use std::error::Error;
 
-use cedar_agent::data::memory::MemoryDataStore;
 use cedar_agent::data::load_from_file::load_entities_from_file;
+use cedar_agent::data::memory::MemoryDataStore;
+use cedar_agent::schemas::authorization::AuthorizationCall;
+use cedar_agent::schemas::authorization::AuthorizationRequest;
 use cedar_agent::DataStore;
+use cedar_policy::Entities;
 
 #[tokio::test]
 async fn memory_tests() {
@@ -24,6 +28,111 @@ async fn memory_tests() {
 
 #[tokio::test]
 async fn test_load_entities_from_file() {
-    let entities = load_entities_from_file(PathBuf::from("./examples/data.json")).await.unwrap();
+    let entities = load_entities_from_file(PathBuf::from("./examples/data.json"))
+        .await
+        .unwrap();
     assert_eq!(entities.len(), 12);
+}
+
+#[tokio::test]
+async fn test_load_empty_entities_from_authz_call() {   
+
+    let entities: String = String::from("[]");
+
+    let query = make_authz_call(entities);        
+
+    match query {
+        Ok(req) => assert_eq!(req.get_entities().unwrap(), Entities::empty()),
+        _ => assert!(false),
+    };
+}
+
+#[tokio::test]
+async fn test_load_no_entities_from_authz_call() {       
+
+    let query = make_authz_call_no_entities();
+
+    match query {
+        Ok(req) => assert_eq!(req.get_entities(), None),
+        _ => assert!(false),
+    };
+}
+
+
+#[tokio::test]
+async fn test_load_entities_from_authz_call() {   
+
+    let entities: String = r#"
+    [
+        {
+            "attrs": {},
+            "parents": [
+                {
+                    "id": "Admin",
+                    "type": "Role"
+                }
+            ],
+            "uid": {
+                "id": "admin.1@domain.com",
+                "type": "User"
+            }
+        },
+        {
+            "attrs": {},
+            "parents": [
+                {
+                    "id": "Admin",
+                    "type": "Role"
+                }
+            ],
+            "uid": {
+                "id": "delete",
+                "type": "Action"
+            }
+        }
+    ]
+    "#
+    .to_string();
+
+    let query = make_authz_call(entities);    
+
+    match query {
+        Ok(req) => {                        
+            assert_ne!(req.get_entities(), None);            
+        },
+        _ => assert!(false)        
+    };
+}
+
+fn make_authz_call_no_entities() -> Result<AuthorizationRequest, Box<dyn Error>> {
+    let principal: Option<String> = Some("User::\"Test\"".to_string());
+    let action: Option<String> = Some("Action::\"Delete\"".to_string());
+    let resource: Option<String> = Some("Document::\"cedar-agent.pdf\"".to_string());
+
+    let authorization_call = AuthorizationCall::new(
+        principal,
+        action,
+        resource,
+        None,
+        None,
+        None,
+    );
+    return authorization_call.try_into();
+}
+
+fn make_authz_call(entities: String) -> Result<AuthorizationRequest, Box<dyn Error>> {
+    let principal: Option<String> = Some("User::\"Test\"".to_string());
+    let action: Option<String> = Some("Action::\"Delete\"".to_string());
+    let resource: Option<String> = Some("Document::\"cedar-agent.pdf\"".to_string());
+
+    let authorization_call = AuthorizationCall::new(
+        principal,
+        action,
+        resource,
+        None,
+        rocket::serde::json::from_str(&entities).unwrap(),
+        None,
+    );
+    return authorization_call.try_into();
+
 }


### PR DESCRIPTION
Description: Add an ability to override the entities stored in datastore by directly passing it into is_authorized REST API call. 

Example body of a REST call for is_authorized with entities passed in with the request


```
{
    "principal": "User::\"admin.1@domain.com\"",
    "action": "Action::\"delete\"",
    "resource": "Document::\"cedar-agent.pdf\"",
    "entities": [
        {
            "attrs": {},
            "parents": [
                {
                    "id": "Admin",
                    "type": "Role"
                }
            ],
            "uid": {
                "id": "admin.1@domain.com",
                "type": "User"
            }
        },
        {
            "attrs": {},
            "parents": [
                {
                    "id": "Admin",
                    "type": "Role"
                }
            ],
            "uid": {
                "id": "delete",
                "type": "Action"
            }
        }
    ],
    "context": {}
}

```