### PR TITLE
Environment variable prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,22 +84,22 @@ cargo build
 Cedar Agent configuration is available using environment variables and command line arguments.
 
 - The port on which the Cedar Agent will listen for incoming HTTP requests. Defaults to `8180`.  
-  `PORT` environment variable.  
+  `CEDAR_AGENT_PORT` environment variable.  
   `--port`, `-p` command line argument.
 - Authentication token to enforce using the `Authorization` header. Defaults to `None`.  
-  `AUTHENTICATION` environment variable.  
+  `CEDAR_AGENT_AUTHENTICATION` environment variable.  
   `--authentication`, `-a` command line argument.
 - The address of the HTTP server. Defaults to `127.0.0.1`.  
-  `ADDR` environment variable.  
+  `CEDAR_AGENT_ADDR` environment variable.  
   `--addr` command line argument.
 - The log level to filter logs. Defaults to `info`.  
-  `LOG_LEVEL` environment variable.  
+  `CEDAR_AGENT_LOG_LEVEL` environment variable.  
   `--log-level`, `-l` command line argument.
 - Load data from json file. Defaults to `None`.  
-  `DATA` environment variable.
+  `CEDAR_AGENT_DATA` environment variable.
   `--data`, `-d` command line argument.
 - Load policies from json file. Defaults to `None`.
-  `POLICIES` environment variable.
+  `CEDAR_AGENT_POLICIES` environment variable.
   `--policies` command line argument.
 
 **command line arguments take precedence over environment variables when configuring the Cedar Agent**

--- a/src/config.rs
+++ b/src/config.rs
@@ -81,7 +81,7 @@ impl Config {
     }
 
     fn from_env() -> Self {
-        match envy::from_env() {
+        match envy::prefixed("CEDAR_AGENT_").from_env() {
             Ok(env) => env,
             Err(_) => Self::new(),
         }

--- a/src/config.rs
+++ b/src/config.rs
@@ -81,10 +81,16 @@ impl Config {
     }
 
     fn from_env() -> Self {
-        match envy::prefixed("CEDAR_AGENT_").from_env() {
+        let old_env = match envy::from_env() {
             Ok(env) => env,
             Err(_) => Self::new(),
-        }
+        };
+        let env = match envy::prefixed("CEDAR_AGENT_").from_env() {
+            Ok(env) => env,
+            Err(_) => Self::new(),
+        };
+
+        Config::merge(vec![old_env, env])
     }
 }
 


### PR DESCRIPTION
**Reason:** The environment variables were too generic for example: DATA, this could cause conflicts in shared environments with other applications.

**What PR does:** It adds a `"CEDAR_AGENT_"` prefix to all cedar agent environment variables, this resolves possible conflicts with other applications that use this same variable, in addition to maintaining support for those using variables in the format without the prefix, that is, old users of the system can apply this update without any problem.

**NOTE:** As mentioned earlier, I've added support for those using environment variables without the prefix, but I've changed the README for variables with the prefix to enforce usage with the prefix for new users of the system.