### PR TITLE
Add optional additional entities to authz request

### DIFF
--- a/src/schemas/authorization.rs
+++ b/src/schemas/authorization.rs
@@ -19,34 +19,41 @@ pub struct AuthorizationCall {
     resource: Option<String>,
     context: Option<serde_json::Value>,
     entities: Option<serde_json::Value>,
+    additional_entities: Option<serde_json::Value>,
     /// Optional schema in JSON format.
     /// If present, this will inform the parsing: for instance, it will allow
     /// `__entity` and `__extn` escapes to be implicit, and it will error if
     /// attributes have the wrong types (e.g., string instead of integer).
     /// currently unsupported
     #[schemars(skip)]
-    policies: Option<String>,  
-    
+    policies: Option<String>,
 }
 
 pub struct AuthorizationRequest {
     request: Request,
-    entities: Option<Entities>
+    entities: Option<Entities>,
+    additional_entities: Option<Entities>,
 }
 
 impl AuthorizationRequest {
-
-    pub fn new(request: Request, entities: Option<Entities>) -> AuthorizationRequest {
-        AuthorizationRequest { request, entities }
+    pub fn new(
+        request: Request,
+        entities: Option<Entities>,
+        additional_entities: Option<Entities>,
+    ) -> AuthorizationRequest {
+        AuthorizationRequest {
+            request,
+            entities,
+            additional_entities,
+        }
     }
 
     pub fn get_entities(self) -> Option<Entities> {
         self.entities
     }
 
-    pub fn get_request_entities(self) -> (Request, Option<Entities>) {        
-
-        (self.request, self.entities)
+    pub fn get_request_entities(self) -> (Request, Option<Entities>, Option<Entities>) {
+        (self.request, self.entities, self.additional_entities)
     }
 }
 
@@ -61,11 +68,25 @@ fn string_to_euid(optional_str: Option<String>) -> Result<Option<EntityUid>, Par
 }
 
 impl AuthorizationCall {
-
-    pub fn new(principal: Option<String>, action: Option<String>, resource: Option<String>, context:Option<rocket::serde::json::Value>, entities:Option<rocket::serde::json::Value>, policies: Option<String>) -> AuthorizationCall {
-        AuthorizationCall { principal, action, resource, context, entities, policies }
+    pub fn new(
+        principal: Option<String>,
+        action: Option<String>,
+        resource: Option<String>,
+        context: Option<rocket::serde::json::Value>,
+        entities: Option<rocket::serde::json::Value>,
+        additional_entities: Option<rocket::serde::json::Value>,
+        policies: Option<String>,
+    ) -> AuthorizationCall {
+        AuthorizationCall {
+            principal,
+            action,
+            resource,
+            context,
+            entities,
+            additional_entities,
+            policies,
+        }
     }
-
 }
 
 impl TryInto<AuthorizationRequest> for AuthorizationCall {
@@ -84,11 +105,18 @@ impl TryInto<AuthorizationRequest> for AuthorizationCall {
             Ok(r) => r,
             Err(e) => return Err(e.into()),
         };
-        let entities = match self.entities {            
+        let entities = match self.entities {
             Some(et) => match Entities::from_json_value(et, None) {
                 Ok(et) => {
                     Some(et)
                 },
+                Err(e) => return Err(e.into()),
+            },
+            None => None,
+        };
+        let additional_entities = match self.additional_entities {
+            Some(et) => match Entities::from_json_value(et, None) {
+                Ok(et) => Some(et),
                 Err(e) => return Err(e.into()),
             },
             None => None,
@@ -100,7 +128,11 @@ impl TryInto<AuthorizationRequest> for AuthorizationCall {
             },
             None => Context::empty(),
         };
-        Ok(AuthorizationRequest::new(Request::new(principal, action, resource, context), entities))
+        Ok(AuthorizationRequest::new(
+            Request::new(principal, action, resource, context),
+            entities,
+            additional_entities,
+        ))
     }
 }
 

--- a/tests/services/data_tests.rs
+++ b/tests/services/data_tests.rs
@@ -35,11 +35,11 @@ async fn test_load_entities_from_file() {
 }
 
 #[tokio::test]
-async fn test_load_empty_entities_from_authz_call() {   
+async fn test_load_empty_entities_from_authz_call() {
 
     let entities: String = String::from("[]");
 
-    let query = make_authz_call(entities);        
+    let query = make_authz_call(entities);
 
     match query {
         Ok(req) => assert_eq!(req.get_entities().unwrap(), Entities::empty()),
@@ -48,7 +48,7 @@ async fn test_load_empty_entities_from_authz_call() {
 }
 
 #[tokio::test]
-async fn test_load_no_entities_from_authz_call() {       
+async fn test_load_no_entities_from_authz_call() {
 
     let query = make_authz_call_no_entities();
 
@@ -60,7 +60,7 @@ async fn test_load_no_entities_from_authz_call() {
 
 
 #[tokio::test]
-async fn test_load_entities_from_authz_call() {   
+async fn test_load_entities_from_authz_call() {
 
     let entities: String = r#"
     [
@@ -89,13 +89,13 @@ async fn test_load_entities_from_authz_call() {
     "#
     .to_string();
 
-    let query = make_authz_call(entities);    
+    let query = make_authz_call(entities);
 
     match query {
-        Ok(req) => {                        
-            assert_ne!(req.get_entities(), None);            
+        Ok(req) => {
+            assert_ne!(req.get_entities(), None);
         },
-        _ => assert!(false)        
+        _ => assert!(false)
     };
 }
 
@@ -108,6 +108,7 @@ fn make_authz_call_no_entities() -> Result<AuthorizationRequest, Box<dyn Error>>
         principal,
         action,
         resource,
+        None,
         None,
         None,
         None,
@@ -126,6 +127,7 @@ fn make_authz_call(entities: String) -> Result<AuthorizationRequest, Box<dyn Err
         resource,
         None,
         rocket::serde::json::from_str(&entities).unwrap(),
+        None,
         None,
     );
     return authorization_call.try_into();


### PR DESCRIPTION
Added an option to pass in entities to authorization requests that would not overwrite the configuration already stored in memory, but modify it by adding new entities to it.

Should be used if your use case has a large amount of entities that is infeasible to store in memory and you have easy access to all relevant entities when making the authorization request.

Fixes #22

This is my first Rust PR. Open and welcoming to feedback.

Would have added tests if the architecture was set up already. Sadly, for integration tests it is not and unit tests are meaningless here.